### PR TITLE
Add benchmarks for all client commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ keywords = ["datadog", "dogstatsd", "client"]
 
 [dependencies]
 chrono = "0.2"
+
+[features]
+unstable = []

--- a/README.md
+++ b/README.md
@@ -63,3 +63,11 @@ client.event("My Custom Event Title", "My Custom Event Body", vec![]).unwrap();
 // Add tags to any metric by passing a Vec<String> of tags to apply
 client.gauge("my_gauge", "12345", vec!["tag:1".into(), "tag:2".into()]).unwrap();
 ```
+
+## Benchmarks
+
+Support is provided for running benchmarks of all client commands. Until the
+`Bencher` type is stable Rust, the benchmarks are isolated behind the
+`unstable` feature flag. To run the benchmarks using `rustup`:
+
+    rustup run nightly cargo bench --features=unstable

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@
 //! client.gauge("my_gauge", "12345", vec!["tag:1".into(), "tag:2".into()]).unwrap();
 //! ```
 
+#![cfg_attr(feature = "unstable", feature(test))]
 #![deny(warnings, missing_debug_implementations, missing_copy_implementations, missing_docs)]
 extern crate chrono;
 
@@ -342,5 +343,90 @@ mod tests {
         let client = Client::new(options);
         // Shouldn't panic or error
         client.send(GaugeMetric::new("gauge".into(), "1234".into()), vec!["tag1".into(), "tag2".into()]).unwrap();
+    }
+}
+
+#[cfg(all(feature = "unstable", test))]
+mod bench {
+    extern crate test;
+    use self::test::Bencher;
+    use super::*;
+
+    #[bench]
+    fn bench_incr(b: &mut Bencher) {
+        let options = Options::default();
+        let client = Client::new(options);
+        let tags = vec!["name1:value1".to_string(), "name2:value2".to_string()];
+        b.iter(|| {
+            client.incr("bench.incr", tags.clone()).unwrap();
+        })
+    }
+
+    #[bench]
+    fn bench_decr(b: &mut Bencher) {
+        let options = Options::default();
+        let client = Client::new(options);
+        let tags = vec!["name1:value1".to_string(), "name2:value2".to_string()];
+        b.iter(|| {
+            client.decr("bench.decr", tags.clone()).unwrap();
+        })
+    }
+
+    #[bench]
+    fn bench_timing(b: &mut Bencher) {
+        let options = Options::default();
+        let client = Client::new(options);
+        let tags = vec!["name1:value1".to_string(), "name2:value2".to_string()];
+        let mut i = 0;
+        b.iter(|| {
+            client.timing("bench.timing", i, tags.clone()).unwrap();
+            i += 1;
+        })
+    }
+
+    #[bench]
+    fn bench_gauge(b: &mut Bencher) {
+        let options = Options::default();
+        let client = Client::new(options);
+        let tags = vec!["name1:value1".to_string(), "name2:value2".to_string()];
+        let mut i = 0;
+        b.iter(|| {
+            client.gauge("bench.timing", &i.to_string(), tags.clone()).unwrap();
+            i += 1;
+        })
+    }
+
+    #[bench]
+    fn bench_histogram(b: &mut Bencher) {
+        let options = Options::default();
+        let client = Client::new(options);
+        let tags = vec!["name1:value1".to_string(), "name2:value2".to_string()];
+        let mut i = 0;
+        b.iter(|| {
+            client.histogram("bench.timing", &i.to_string(), tags.clone()).unwrap();
+            i += 1;
+        })
+    }
+
+    #[bench]
+    fn bench_set(b: &mut Bencher) {
+        let options = Options::default();
+        let client = Client::new(options);
+        let tags = vec!["name1:value1".to_string(), "name2:value2".to_string()];
+        let mut i = 0;
+        b.iter(|| {
+            client.set("bench.timing", &i.to_string(), tags.clone()).unwrap();
+            i += 1;
+        })
+    }
+
+    #[bench]
+    fn bench_event(b: &mut Bencher) {
+        let options = Options::default();
+        let client = Client::new(options);
+        let tags = vec!["name1:value1".to_string(), "name2:value2".to_string()];
+        b.iter(|| {
+            client.event("Test Event Title", "Test Event Message", tags.clone()).unwrap();
+        })
     }
 }


### PR DESCRIPTION
Adds benchmarks for all client commands. Since the `Bencher` type is unstable in Rust (as of 1.16.0), the benchmarks are placed behind an `unstable` feature flag.

Benchmarks may be easily run using rustup:

    rustup run nightly cargo bench --features=unstable

Preliminary benchmark results on a 2015 MacBook Pro (2.5 GHz Intel Core
i7):

    test bench::bench_decr      ... bench:     137,422 ns/iter (+/- 317,266)
    test bench::bench_event     ... bench:     157,708 ns/iter (+/- 279,659)
    test bench::bench_gauge     ... bench:     138,378 ns/iter (+/- 254,691)
    test bench::bench_histogram ... bench:     157,012 ns/iter (+/- 308,771)
    test bench::bench_incr      ... bench:     183,358 ns/iter (+/- 305,843)
    test bench::bench_set       ... bench:     177,160 ns/iter (+/- 308,811)
    test bench::bench_timing    ... bench:     163,766 ns/iter (+/- 293,362)