### PR TITLE
Use automatic port for UDP send

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Build an options struct and create a client:
 ```rust
 use dogstatsd::{Client, Options};
 
-// Binds to a udp socket on 127.0.0.1:8126 for transmitting, and sends to
-// 127.0.0.1:8125, the default dogstatsd address.
+// Binds to a udp socket on an available ephemeral port on 127.0.0.1 for
+// transmitting, and sends to 127.0.0.1:8125, the default dogstatsd address.
 let default_options = Options::default();
 let default_client = Client::new(default_options);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,9 @@
 //! ```
 //! use dogstatsd::{Client, Options};
 //!
-//! // Binds to a udp socket on 127.0.0.1:8126 for transmitting, and sends to
-//! // 127.0.0.1:8125, the default dogstatsd address.
+//! // Binds to a udp socket on an available ephemeral port on 127.0.0.1 for
+//! // transmitting, and sends to  127.0.0.1:8125, the default dogstatsd
+//! // address.
 //! let default_options = Options::default();
 //! let default_client = Client::new(default_options);
 //!
@@ -97,7 +98,7 @@ impl Options {
     ///
     ///   assert_eq!(
     ///       Options {
-    ///           from_addr: "127.0.0.1:8126".into(),
+    ///           from_addr: "127.0.0.1:0".into(),
     ///           to_addr: "127.0.0.1:8125".into(),
     ///           namespace: String::new(),
     ///       },
@@ -106,7 +107,7 @@ impl Options {
     /// ```
     pub fn default() -> Self {
         Options {
-            from_addr: "127.0.0.1:8126".into(),
+            from_addr: "127.0.0.1:0".into(),
             to_addr: "127.0.0.1:8125".into(),
             namespace: String::new(),
         }
@@ -308,7 +309,7 @@ mod tests {
     fn test_options_default() {
         let options = Options::default();
         let expected_options = Options {
-            from_addr: "127.0.0.1:8126".into(),
+            from_addr: "127.0.0.1:0".into(),
             to_addr: "127.0.0.1:8125".into(),
             namespace: String::new(),
         };
@@ -320,7 +321,7 @@ mod tests {
     fn test_new() {
         let client = Client::new(Options::default());
         let expected_client = Client {
-            from_addr: "127.0.0.1:8126".into(),
+            from_addr: "127.0.0.1:0".into(),
             to_addr: "127.0.0.1:8125".into(),
             namespace: String::new(),
         };


### PR DESCRIPTION
Use an automatically-assigned free UDP port in the ephemeral port range for sending by default. Since none of the DataDog metrics require two-way communication, the assigned port number does not need to be remembered/exposed.

This avoids port conflicts if more than one `Client` is being used at the same time from different threads.