### PR TITLE
Decrease allocations. Don't force caller to allocate.

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RustProjectSettings">
+    <option name="toolchainHomeDirectory" value="$USER_HOME$/.cargo/bin" />
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>


### PR DESCRIPTION
Hey, I've been using dogstatsd, and it's great, but it has forced me to convert some slices to vecs, &str to String, and things like that, incurring copies.

I noticed the internal code also does more copying than is necessary. It also uses format!, which doesn't preallocate buffers.

I went ahead and replaced all of the Vec and String with slices where applicable. I've also replaced all format! macros with string building, and shuffled a few branches around.

The performance improvement is around 5%. It *does* break the API. S is now Into<&str> instead of Into<String<, which I think is breaking. Vec becoming &[&str] is definitely breaking.

Before:

test bench::bench_decr                     ... bench:       5,562 ns/iter (+/- 443)
test bench::bench_event                    ... bench:       5,383 ns/iter (+/- 1,582)
test bench::bench_gauge                    ... bench:       5,701 ns/iter (+/- 409)
test bench::bench_histogram                ... bench:       5,644 ns/iter (+/- 362)
test bench::bench_incr                     ... bench:       5,545 ns/iter (+/- 323)
test bench::bench_set                      ... bench:       5,645 ns/iter (+/- 324)
test bench::bench_timing                   ... bench:       5,544 ns/iter (+/- 292)
test metrics::bench::bench_format_for_send ... bench:         333 ns/iter (+/- 15)
test metrics::bench::bench_set_counter     ... bench:          86 ns/iter (+/- 3)
test metrics::bench::bench_set_metric      ... bench:         202 ns/iter (+/- 99)

After:

test bench::bench_decr                     ... bench:       5,123 ns/iter (+/- 482)
test bench::bench_event                    ... bench:       5,397 ns/iter (+/- 350)
test bench::bench_gauge                    ... bench:       5,218 ns/iter (+/- 504)
test bench::bench_histogram                ... bench:       5,196 ns/iter (+/- 316)
test bench::bench_incr                     ... bench:       5,099 ns/iter (+/- 332)
test bench::bench_set                      ... bench:       5,241 ns/iter (+/- 419)
test bench::bench_timing                   ... bench:       5,264 ns/iter (+/- 447)
test metrics::bench::bench_format_for_send ... bench:         111 ns/iter (+/- 7)
test metrics::bench::bench_set_counter     ... bench:          29 ns/iter (+/- 0)
test metrics::bench::bench_set_metric      ... bench:          32 ns/iter (+/- 1)

