### PR TITLE
Make DogstatsdError-type publicly available

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,11 @@
 use std::error::Error;
 use std::{fmt, io};
 
+/// This type represents the possible errors that can occur while
+/// sending DogstatsD metrics.
 #[derive(Debug)]
 pub enum DogstatsdError {
+    /// Chained IO errors.
     IoError(io::Error),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ use std::net::UdpSocket;
 use std::borrow::Cow;
 
 mod error;
-use self::error::DogstatsdError;
+pub use self::error::DogstatsdError;
 
 mod metrics;
 use self::metrics::*;


### PR DESCRIPTION
When consuming this crate's API it is sometimes desirable to be able
to access the internal error type in other code, for example when
setting up error chains or writing type-specific handler logic.

This change exposes the error type by publicly using it from the
`errors` module and adds (admittedly very simple) documentation on the
error type itself.

----

PS: Thanks for this library! Really like the API :)