### PR TITLE
Various updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["datadog", "dogstatsd", "client"]
 
 [dependencies]
 chrono = "0.4"
+rand = "0.3"
 
 [features]
 unstable = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -399,10 +399,7 @@ impl Client {
               T: AsRef<str>,
     {
         let unwrapped_options = options.unwrap_or(ServiceCheckOptions::default());
-        match stat.into() {
-            Cow::Borrowed(stat) => self.send(&ServiceCheck::new(stat, val, unwrapped_options), tags),
-            Cow::Owned(stat) => self.send(&ServiceCheck::new(&stat, val, unwrapped_options), tags),
-        }
+        self.send(&ServiceCheck::new(stat.into().borrow(), val, unwrapped_options), tags)
     }
 
     /// Send a custom event as a title and a body
@@ -450,13 +447,13 @@ impl<'a> Measure<'a> for &'a str {
 
 impl<'a> Measure<'a> for i64 {
     fn to_cow(&self) -> Cow<'a, str> {
-        Cow::from(format!("{}", self))
+        Cow::from(format!("{:.6}", self))
     }
 }
 
 impl<'a> Measure<'a> for f64 {
     fn to_cow(&self) -> Cow<'a, str> {
-        Cow::from(format!("{}", self)) // TODO: this changes the format
+        Cow::from(format!("{:.6}", self))
     }
 }
 
@@ -469,6 +466,13 @@ pub trait DurationMeasure {
 impl DurationMeasure for i64 {
     fn as_milliseconds(&self) -> i64 {
         *self
+    }
+}
+
+impl DurationMeasure for std::time::Duration {
+    fn as_milliseconds(&self) -> i64 {
+        // TODO this ignores subseconds in the duration
+        self.as_secs() as i64 * 1000
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@
 //! client.set("my_set", "13579", tags).unwrap();
 //!
 //! // Send a custom event
-//! client.event("My Custom Event Title", "My Custom Event Body", tags).unwrap();
+//! client.event("My Custom Event Title", "My Custom Event Body", tags, None).unwrap();
 //! ```
 
 #![cfg_attr(feature = "unstable", feature(test))]
@@ -445,11 +445,11 @@ impl<'c> Client<'c> {
     ///   ).unwrap();
     ///   # }
     /// ```
-    pub fn service_check<I>(&self, stat: &str, val: ServiceStatus, tags: I, options: Option<ServiceCheckOptions>) -> DogstatsdResult
+    pub fn service_check<I>(&self, stat: &str, status: ServiceStatus, tags: I, options: Option<ServiceCheckOptions>) -> DogstatsdResult
         where I: IntoIterator, I::Item: AsRef<str>
     {
         let opt = options.unwrap_or(ServiceCheckOptions::default());
-        self.send(&Metric::ServiceCheck { stat, val, opt }, tags)
+        self.send(&Metric::ServiceCheck { stat, status, opt }, tags)
     }
 
     /// Send a custom event as a title and a body
@@ -460,12 +460,13 @@ impl<'c> Client<'c> {
     ///   use dogstatsd::Client;
     ///
     ///   let client = Client::new().unwrap();
-    ///   client.event("Event Title", "Event Body", &["tag:event"]).unwrap();
+    ///   client.event("Event Title", "Event Body", &["tag:event"], None).unwrap();
     /// ```
-    pub fn event<I>(&self, title: &str, text: &str, tags: I) -> DogstatsdResult
+    pub fn event<I>(&self, title: &str, text: &str, tags: I, options: Option<EventOptions>) -> DogstatsdResult
         where I: IntoIterator, I::Item: AsRef<str>
     {
-        self.send(&Metric::Event { title, text }, tags)
+        let opt = options.unwrap_or(EventOptions::default());
+        self.send(&Metric::Event { title, text, opt }, tags)
     }
 
     fn send<I>(&self, metric: &Metric, tags: I) -> DogstatsdResult

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -356,6 +356,9 @@ impl Client {
     /// # Examples
     ///
     /// ```
+    ///   # extern crate chrono;
+    ///   # extern crate dogstatsd;
+    ///   # fn main() {
     ///   use dogstatsd::{Client, ServiceStatus, ServiceCheckOptions};
     ///
     ///   let client = Client::new().unwrap();
@@ -373,10 +376,11 @@ impl Client {
     ///   client.service_check("redis.can_connect", ServiceStatus::OK, tags, 
     ///     Some(ServiceCheckOptions {
     ///       hostname: Some("my-host.localhost"),
-    ///       timestamp: Some(1510326433),
+    ///       timestamp: Some(chrono::Utc::now().into()),
     ///       message: Some("Message about the check or service")
     ///     })
     ///   ).unwrap();
+    ///   # }
     /// ```
     pub fn service_check<I>(&self, stat: &str, val: ServiceStatus, tags: I, options: Option<ServiceCheckOptions>) -> DogstatsdResult
         where I: IntoIterator, I::Item: AsRef<str>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,9 +185,8 @@ impl Client {
     ///   client.incr("counter", &["tag:counter"])
     ///       .unwrap_or_else(|e| println!("Encountered error: {}", e));
     /// ```
-    pub fn incr<I, T>(&self, stat: &str, tags: I) -> DogstatsdResult
-        where I: IntoIterator<Item=T>,
-              T: AsRef<str>,
+    pub fn incr<I>(&self, stat: &str, tags: I) -> DogstatsdResult
+        where I: IntoIterator, I::Item: AsRef<str>
     {
         let val = 1;
         self.send(&Metric::Count { stat, val: val.into() }, tags)
@@ -204,9 +203,8 @@ impl Client {
     ///   client.decr("counter", &["tag:counter"])
     ///       .unwrap_or_else(|e| println!("Encountered error: {}", e));
     /// ```
-    pub fn decr<I, T>(&self, stat: &str, tags: I) -> DogstatsdResult
-        where I: IntoIterator<Item=T>,
-              T: AsRef<str>,
+    pub fn decr<I>(&self, stat: &str, tags: I) -> DogstatsdResult
+        where I: IntoIterator, I::Item: AsRef<str>
     {
         let val = -1;
         self.send(&Metric::Count { stat, val: val.into() }, tags)
@@ -226,10 +224,9 @@ impl Client {
     ///       thread::sleep(Duration::from_millis(200))
     ///   }).unwrap_or_else(|e| println!("Encountered error: {}", e))
     /// ```
-    pub fn time<F, I, T>(&self, stat: &str, tags: I, block: F) -> DogstatsdResult
-        where F: FnOnce(),
-              I: IntoIterator<Item=T>,
-              T: AsRef<str>,
+    pub fn time<I, F>(&self, stat: &str, tags: I, block: F) -> DogstatsdResult
+        where I: IntoIterator, I::Item: AsRef<str>,
+              F: FnOnce()
     {
         let start_time = Utc::now();
         block();
@@ -255,10 +252,9 @@ impl Client {
     ///       .unwrap_or_else(|e| println!("Encountered error: {}", e));
     ///   # }
     /// ```
-    pub fn timing<I, T, V>(&self, stat: &str, duration: V, tags: I) -> DogstatsdResult
-        where I: IntoIterator<Item=T>,
-              T: AsRef<str>,
-              V: Into<DurationMeasurement>,
+    pub fn timing<I, V>(&self, stat: &str, duration: V, tags: I) -> DogstatsdResult
+        where I: IntoIterator, I::Item: AsRef<str>,
+              V: Into<DurationMeasurement>
     {
         self.send(&Metric::Timing { stat, val: duration.into() }, tags)
     }
@@ -276,10 +272,9 @@ impl Client {
     ///   client.gauge("gauge", 123.45, &["tag:gauge"])
     ///       .unwrap_or_else(|e| println!("Encountered error: {}", e));
     /// ```
-    pub fn gauge<I, T, V>(&self, stat: &str, val: V, tags: I) -> DogstatsdResult
-        where I: IntoIterator<Item=T>,
-              T: AsRef<str>,
-              V: Into<Measurement>,
+    pub fn gauge<I, V>(&self, stat: &str, val: V, tags: I) -> DogstatsdResult
+        where I: IntoIterator, I::Item: AsRef<str>,
+              V: Into<Measurement>
     {
         self.send(&Metric::Gauge { stat, val: val.into() }, tags)
     }
@@ -295,10 +290,9 @@ impl Client {
     ///   client.histogram("histogram", 67.890, &["tag:histogram"])
     ///       .unwrap_or_else(|e| println!("Encountered error: {}", e));
     /// ```
-    pub fn histogram<I, T, V>(&self, stat: &str, val: V, tags: I) -> DogstatsdResult
-        where I: IntoIterator<Item=T>,
-              T: AsRef<str>,
-              V: Into<Measurement>,
+    pub fn histogram<I, V>(&self, stat: &str, val: V, tags: I) -> DogstatsdResult
+        where I: IntoIterator, I::Item: AsRef<str>,
+              V: Into<Measurement>
     {
         self.send(&Metric::Histogram { stat, val: val.into() }, tags)
     }
@@ -316,10 +310,9 @@ impl Client {
     ///   client.distribution("distribution", 67.890, &["tag:distribution"])
     ///       .unwrap_or_else(|e| println!("Encountered error: {}", e));
     /// ```
-    pub fn distribution<I, T, V>(&self, stat: &str, val: V, tags: I) -> DogstatsdResult
-        where I: IntoIterator<Item=T>,
-              T: AsRef<str>,
-              V: Into<Measurement>,
+    pub fn distribution<I, V>(&self, stat: &str, val: V, tags: I) -> DogstatsdResult
+        where I: IntoIterator, I::Item: AsRef<str>,
+              V: Into<Measurement>
     {
         self.send(&Metric::Distribution { stat, val: val.into() }, tags)
     }
@@ -335,10 +328,9 @@ impl Client {
     ///   client.set("set", 13579, &["tag:set"])
     ///       .unwrap_or_else(|e| println!("Encountered error: {}", e));
     /// ```
-    pub fn set<I, T, V>(&self, stat: &str, val: V, tags: I) -> DogstatsdResult
-        where I: IntoIterator<Item=T>,
-              T: AsRef<str>,
-              V: Into<Measurement>,
+    pub fn set<I, V>(&self, stat: &str, val: V, tags: I) -> DogstatsdResult
+        where I: IntoIterator, I::Item: AsRef<str>,
+              V: Into<Measurement>
     {
         self.send(&Metric::Set { stat, val: val.into() }, tags)
     }
@@ -369,9 +361,8 @@ impl Client {
     ///   client.service_check("redis.can_connect", ServiceStatus::OK, &["tag:service"], Some(all_options))
     ///       .unwrap_or_else(|e| println!("Encountered error: {}", e));
     /// ```
-    pub fn service_check<I, T>(&self, stat: &str, val: ServiceStatus, tags: I, options: Option<ServiceCheckOptions>) -> DogstatsdResult
-        where I: IntoIterator<Item=T>,
-              T: AsRef<str>,
+    pub fn service_check<I>(&self, stat: &str, val: ServiceStatus, tags: I, options: Option<ServiceCheckOptions>) -> DogstatsdResult
+        where I: IntoIterator, I::Item: AsRef<str>
     {
         let opt = options.unwrap_or(ServiceCheckOptions::default());
         self.send(&Metric::ServiceCheck { stat, val, opt }, tags)
@@ -388,16 +379,14 @@ impl Client {
     ///   client.event("Event Title", "Event Body", &["tag:event"])
     ///       .unwrap_or_else(|e| println!("Encountered error: {}", e));
     /// ```
-    pub fn event<I, T>(&self, title: &str, text: &str, tags: I) -> DogstatsdResult
-        where I: IntoIterator<Item=T>,
-              T: AsRef<str>,
+    pub fn event<I>(&self, title: &str, text: &str, tags: I) -> DogstatsdResult
+        where I: IntoIterator, I::Item: AsRef<str>
     {
         self.send(&Metric::Event { title, text }, tags)
     }
 
-    fn send<I, T>(&self, metric: &Metric, tags: I) -> DogstatsdResult
-        where I: IntoIterator<Item=T>,
-              T: AsRef<str>,
+    fn send<I>(&self, metric: &Metric, tags: I) -> DogstatsdResult
+        where I: IntoIterator, I::Item: AsRef<str>
     {
         let formatted_metric = format_for_send(metric, &self.namespace, tags);
         self.socket.send_to(formatted_metric.as_slice(), &self.to_addr)?;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -111,6 +111,12 @@ impl<'a> Metric for TimingMetric<'a> {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+pub enum Measurement {
+    Int(i64),
+    Float(f64),
+}
+
 macro_rules! measurement_metric {
     ($t:ident, $suffix:expr) => (
 
@@ -138,23 +144,36 @@ macro_rules! measurement_metric {
     )
 }
 
-#[derive(Clone, Copy, Debug)]
-pub enum Measurement {
-    Int(i64),
-    Float(f64),
+macro_rules! measurement_from {
+    ($t:ty, Int) => (
+        impl From<$t> for Measurement {
+            fn from(value: $t) -> Measurement {
+                Measurement::Int(value as i64)
+            }
+        }
+    );
+
+    ($t:ty, Float) => (
+        impl From<$t> for Measurement {
+            fn from(value: $t) -> Measurement {
+                Measurement::Float(value as f64)
+            }
+        }
+    )
 }
 
-impl From<i64> for Measurement {
-    fn from(value: i64) -> Measurement {
-        Measurement::Int(value)
-    }
-}
-
-impl From<f64> for Measurement {
-    fn from(value: f64) -> Measurement {
-        Measurement::Float(value)
-    }
-}
+measurement_from!(usize, Int);
+measurement_from!(isize, Int);
+measurement_from!(u8,  Int);
+measurement_from!(i8,  Int);
+measurement_from!(u16, Int);
+measurement_from!(i16, Int);
+measurement_from!(u32, Int);
+measurement_from!(i32, Int);
+measurement_from!(u64, Int);
+measurement_from!(i64, Int);
+measurement_from!(f32, Float);
+measurement_from!(f64, Float);
 
 measurement_metric!(GaugeMetric, "|g");
 measurement_metric!(HistogramMetric, "|h");

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -238,24 +238,13 @@ impl<'a> SetMetric<'a> {
 #[derive(Clone, Copy, Debug)]
 pub enum ServiceStatus {
     /// OK State
-    OK,
+    OK = 0,
     /// Warning State
-    Warning,
+    Warning = 1,
     /// Critical State
-    Critical,
+    Critical = 2,
     /// Unknown State
-    Unknown,
-}
-
-impl ServiceStatus {
-    fn to_int(&self) -> i32 {
-        match *self {
-            ServiceStatus::OK => 0,
-            ServiceStatus::Warning => 1,
-            ServiceStatus::Critical => 2,
-            ServiceStatus::Unknown => 3,
-        }
-    }
+    Unknown = 3,
 }
 
 /// Struct for adding optional pieces to a service check
@@ -306,7 +295,7 @@ impl<'a> Metric for ServiceCheck<'a> {
         buf.push_str("_sc|");
         buf.push_str(self.stat);
         buf.push_str("|");
-        buf.push_str(&format!("{}", self.val.to_int()));
+        buf.push_str(&format!("{}", self.val as u8));
 
         if self.options.timestamp.is_some() {
             buf.push_str("|d:");

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,8 +1,188 @@
-use chrono::{DateTime, Utc};
 
-pub fn format_for_send<M, I, S>(in_metric: &M, in_namespace: &str, tags: I) -> Vec<u8>
-    where M: Metric,
-          I: IntoIterator<Item=S>,
+use std::fmt;
+use chrono;
+
+pub enum Metric<'a> {
+    Count { stat: Stat<'a>, val: Measurement },
+    Gauge { stat: Stat<'a>, val: Measurement },
+    Histogram { stat: Stat<'a>, val: Measurement },
+    Distribution { stat: Stat<'a>, val: Measurement },
+    Set { stat: Stat<'a>, val: Measurement },
+    Timing { stat: Stat<'a>, val: DurationMeasurement },
+    ServiceCheck { stat: Stat<'a>, val: ServiceStatus, opt: ServiceCheckOptions },
+    Event { title: &'a str, text: &'a str },
+}
+
+impl<'a> Metric<'a> {
+
+    pub fn uses_namespace(&self) -> bool {
+        use Metric::*;
+        match self {
+            Event { .. } => false,
+            ServiceCheck { .. } => false,
+            _ => true,
+        }
+    }
+
+    pub fn metric_type_format(&self) -> String {
+        use Metric::*;
+        match self {
+            Count { stat, val }         => format!("{}:{}|c", stat, val),
+            Gauge { stat, val }         => format!("{}:{}|g", stat, val),
+            Histogram { stat, val }     => format!("{}:{}|h", stat, val),
+            Distribution { stat, val }  => format!("{}:{}|d", stat, val),
+            Set { stat, val }           => format!("{}:{}|s", stat, val),
+            Timing { stat, val }        => format!("{}:{}|ms", stat, val),
+            
+            Event { title, text } => {
+                let title_len = title.len().to_string();
+                let text_len = text.len().to_string();
+                let mut buf = String::with_capacity(title.len() + text.len() + title_len.len() + text_len.len() + 6);
+                buf.push_str("_e{");
+                buf.push_str(&title_len);
+                buf.push_str(",");
+                buf.push_str(&text_len);
+                buf.push_str("}:");
+                buf.push_str(title);
+                buf.push_str("|");
+                buf.push_str(text);
+                buf
+            }
+            
+            ServiceCheck { stat, val, opt } => {
+                let mut buf = String::with_capacity(6 + stat.len() + opt.len());
+                buf.push_str("_sc|");
+                buf.push_str(stat);
+                buf.push_str("|");
+                buf.push_str(&format!("{}", *val as u8));
+
+                if let Some(timestamp) = opt.timestamp {
+                    buf.push_str("|d:");
+                    buf.push_str(&format!("{}", timestamp));
+                }
+
+                if let Some(hostname) = opt.hostname {
+                    buf.push_str("|h:");
+                    buf.push_str(hostname);
+                }
+
+                if let Some(message) = opt.message {
+                    buf.push_str("|m:");
+                    buf.push_str(message);
+                }
+
+                buf
+            }
+        }
+    }
+}
+
+pub type Stat<'a> = &'a str;
+
+#[derive(Clone, Copy, Debug)]
+pub enum Measurement {
+    Int(i64),
+    Float(f64),
+}
+
+impl fmt::Display for Measurement {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Measurement::*;
+        match self {
+            Int(val) => write!(f, "{}", val),
+            Float(val) => write!(f, "{:.6}", val),
+        }
+    }
+}
+
+macro_rules! measurement_from {
+    ($t:ty, Int) => (
+        impl From<$t> for Measurement {
+            fn from(value: $t) -> Measurement {
+                Measurement::Int(value as i64)
+            }
+        }
+    );
+
+    ($t:ty, Float) => (
+        impl From<$t> for Measurement {
+            fn from(value: $t) -> Measurement {
+                Measurement::Float(value as f64)
+            }
+        }
+    )
+}
+
+measurement_from!(usize, Int);
+measurement_from!(isize, Int);
+measurement_from!(u8,  Int);
+measurement_from!(i8,  Int);
+measurement_from!(u16, Int);
+measurement_from!(i16, Int);
+measurement_from!(u32, Int);
+measurement_from!(i32, Int);
+measurement_from!(u64, Int);
+measurement_from!(i64, Int);
+measurement_from!(f32, Float);
+measurement_from!(f64, Float);
+
+#[derive(Clone, Copy, Debug)]
+pub struct DurationMeasurement(Measurement);
+
+impl fmt::Display for DurationMeasurement {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<u64> for DurationMeasurement {
+    fn from(value: u64) -> DurationMeasurement {
+        DurationMeasurement(Measurement::Int(value as i64))
+    }
+}
+
+impl From<chrono::Duration> for DurationMeasurement {
+    fn from(value: chrono::Duration) -> DurationMeasurement {
+        DurationMeasurement(Measurement::Int(value.num_milliseconds()))
+    }
+}
+
+/// Represents the different states a service can be in
+#[derive(Clone, Copy, Debug)]
+pub enum ServiceStatus {
+    /// OK State
+    OK = 0,
+    /// Warning State
+    Warning = 1,
+    /// Critical State
+    Critical = 2,
+    /// Unknown State
+    Unknown = 3,
+}
+
+/// Struct for adding optional pieces to a service check
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ServiceCheckOptions {
+    /// An optional timestamp to include with the check
+    pub timestamp: Option<i32>,
+    /// An optional hostname to include with the check
+    pub hostname: Option<&'static str>,
+    /// An optional message to include with the check
+    pub message: Option<&'static str>,
+}
+
+impl ServiceCheckOptions {
+    fn len(&self) -> usize {
+        let mut length = 0;
+        length += self.timestamp.map_or(0, |ts| format!("{}", ts).len() + 3);
+        length += self.hostname.map_or(0, |host| host.len() + 3);
+        length += self.message.map_or(0, |msg| msg.len() + 3);
+        length
+    }
+}
+
+pub fn format_for_send<I, S>(in_metric: &Metric, in_namespace: &str, tags: I) -> Vec<u8>
+    where I: IntoIterator<Item=S>,
           S: AsRef<str>,
 {
     let metric = in_metric.metric_type_format();
@@ -40,263 +220,6 @@ pub fn format_for_send<M, I, S>(in_metric: &M, in_namespace: &str, tags: I) -> V
     buf
 }
 
-pub trait Metric {
-    fn metric_type_format(&self) -> String;
-
-    fn uses_namespace(&self) -> bool {
-        true
-    }
-}
-
-pub enum CountMetric<'a> {
-    Incr(&'a str),
-    Decr(&'a str),
-}
-
-impl<'a> Metric for CountMetric<'a> {
-    // my_count:1|c
-    // my_count:-1|c
-    fn metric_type_format(&self) -> String {
-        match *self {
-            CountMetric::Incr(stat) => {
-                let mut buf = String::with_capacity(3 + stat.len() + 4);
-                buf.push_str(stat);
-                buf.push_str(":1|c");
-                buf
-            },
-            CountMetric::Decr(stat) => {
-                let mut buf = String::with_capacity(3 + stat.len() + 4);
-                buf.push_str(stat);
-                buf.push_str(":-1|c");
-                buf
-            },
-        }
-    }
-}
-
-pub struct TimeMetric<'a> {
-    pub start_time: &'a DateTime<Utc>,
-    pub end_time: &'a DateTime<Utc>,
-    pub stat: &'a str,
-}
-
-impl<'a> Metric for TimeMetric<'a> {
-    // my_stat:500|ms
-    fn metric_type_format(&self) -> String {
-        let dur = self.end_time.signed_duration_since(*self.start_time);
-        let mut buf = String::with_capacity(3 + self.stat.len() + 11);
-        buf.push_str(self.stat);
-        buf.push_str(":");
-        buf.push_str(&dur.num_milliseconds().to_string());
-        buf.push_str("|ms");
-        buf
-    }
-}
-
-pub struct TimingMetric<'a> {
-    pub ms: i64,
-    pub stat: &'a str,
-}
-
-impl<'a> Metric for TimingMetric<'a> {
-    // my_stat:500|ms
-    fn metric_type_format(&self) -> String {
-        let ms = self.ms.to_string();
-        let mut buf = String::with_capacity(3 + self.stat.len() + ms.len());
-        buf.push_str(self.stat);
-        buf.push_str(":");
-        buf.push_str(&ms);
-        buf.push_str("|ms");
-        buf
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-pub enum Measurement {
-    Int(i64),
-    Float(f64),
-}
-
-macro_rules! measurement_from {
-    ($t:ty, Int) => (
-        impl From<$t> for Measurement {
-            fn from(value: $t) -> Measurement {
-                Measurement::Int(value as i64)
-            }
-        }
-    );
-
-    ($t:ty, Float) => (
-        impl From<$t> for Measurement {
-            fn from(value: $t) -> Measurement {
-                Measurement::Float(value as f64)
-            }
-        }
-    )
-}
-
-macro_rules! measurement_metric {
-    ($t:ident, $suffix:expr) => (
-
-        pub struct $t<'a> {
-            pub stat: &'a str,
-            pub val: Measurement,
-        }
-        
-        impl<'a> Metric for $t<'a> {
-            // my_gauge:1000|$suffix
-            fn metric_type_format(&self) -> String {
-                let val = match self.val {
-                    Measurement::Int(i) => format!("{}", i),
-                    Measurement::Float(f) => format!("{:.6}", f),
-                };
-
-                let mut buf = String::with_capacity(3 + self.stat.len() + val.len());
-                buf.push_str(self.stat);
-                buf.push_str(":");
-                buf.push_str(&val);
-                buf.push_str($suffix);
-                buf
-            }
-        }
-    )
-}
-
-measurement_from!(usize, Int);
-measurement_from!(isize, Int);
-measurement_from!(u8,  Int);
-measurement_from!(i8,  Int);
-measurement_from!(u16, Int);
-measurement_from!(i16, Int);
-measurement_from!(u32, Int);
-measurement_from!(i32, Int);
-measurement_from!(u64, Int);
-measurement_from!(i64, Int);
-measurement_from!(f32, Float);
-measurement_from!(f64, Float);
-
-measurement_metric!(GaugeMetric, "|g");
-measurement_metric!(HistogramMetric, "|h");
-measurement_metric!(DistributionMetric, "|d");
-measurement_metric!(SetMetric, "|s");
-
-/// Represents the different states a service can be in
-#[derive(Clone, Copy, Debug)]
-pub enum ServiceStatus {
-    /// OK State
-    OK = 0,
-    /// Warning State
-    Warning = 1,
-    /// Critical State
-    Critical = 2,
-    /// Unknown State
-    Unknown = 3,
-}
-
-/// Struct for adding optional pieces to a service check
-#[derive(Clone, Copy, Debug)]
-pub struct ServiceCheckOptions {
-    /// An optional timestamp to include with the check
-    pub timestamp: Option<i32>,
-    /// An optional hostname to include with the check
-    pub hostname: Option<&'static str>,
-    /// An optional message to include with the check
-    pub message: Option<&'static str>,
-}
-
-impl Default for ServiceCheckOptions {
-    fn default() -> Self {
-        ServiceCheckOptions {
-            timestamp: None,
-            hostname: None,
-            message: None,
-        }
-    }
-}
-
-impl ServiceCheckOptions {
-    fn len(&self) -> usize {
-        let mut length = 0;
-        length += self.timestamp.map_or(0, |ts| format!("{}", ts).len() + 3);
-        length += self.hostname.map_or(0, |host| host.len() + 3);
-        length += self.message.map_or(0, |msg| msg.len() + 3);
-        length
-    }
-}
-
-pub struct ServiceCheck<'a> {
-    pub stat: &'a str,
-    pub val: ServiceStatus,
-    pub options: ServiceCheckOptions,
-}
-
-impl<'a> Metric for ServiceCheck<'a> {
-    fn uses_namespace(&self) -> bool {
-        false
-    }
-
-    // _sc|my_service.can_connect|1
-    fn metric_type_format(&self) -> String {
-        let mut buf = String::with_capacity(6 + self.stat.len() + self.options.len());
-        buf.push_str("_sc|");
-        buf.push_str(self.stat);
-        buf.push_str("|");
-        buf.push_str(&format!("{}", self.val as u8));
-
-        if let Some(timestamp) = self.options.timestamp {
-            buf.push_str("|d:");
-            buf.push_str(&format!("{}", timestamp));
-        }
-
-        if let Some(hostname) = self.options.hostname {
-            buf.push_str("|h:");
-            buf.push_str(hostname);
-        }
-
-        if let Some(message) = self.options.message {
-            buf.push_str("|m:");
-            buf.push_str(message);
-        }
-
-        buf
-    }
-}
-
-pub struct Event<'a> {
-    title: &'a str,
-    text: &'a str,
-}
-
-impl<'a> Metric for Event<'a> {
-    fn uses_namespace(&self) -> bool {
-        false
-    }
-
-    fn metric_type_format(&self) -> String {
-        let title_len = self.title.len().to_string();
-        let text_len = self.text.len().to_string();
-        let mut buf = String::with_capacity(self.title.len() + self.text.len() + title_len.len() + text_len.len() + 6);
-        buf.push_str("_e{");
-        buf.push_str(&title_len);
-        buf.push_str(",");
-        buf.push_str(&text_len);
-        buf.push_str("}:");
-        buf.push_str(self.title);
-        buf.push_str("|");
-        buf.push_str(self.text);
-        buf
-    }
-}
-
-impl<'a> Event<'a> {
-    pub fn new(title: &'a str, text: &'a str) -> Self {
-        Event {
-            title: title,
-            text: text,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use chrono::{TimeZone, Utc};
@@ -306,7 +229,7 @@ mod tests {
     fn test_format_for_send_no_tags() {
         assert_eq!(
             &b"namespace.foo:1|c"[..],
-            &format_for_send(&CountMetric::Incr("foo"), "namespace", &[] as &[String])[..]
+            &format_for_send(&Metric::Count { stat: "foo".into(), val: 1.into() }, "namespace", &[] as &[String])[..]
         )
     }
 
@@ -314,7 +237,7 @@ mod tests {
     fn test_format_for_send_no_namespace() {
         assert_eq!(
             &b"foo:1|c|#tag:1,tag:2"[..],
-            &format_for_send(&CountMetric::Incr("foo"), "", &["tag:1", "tag:2"])[..]
+            &format_for_send(&Metric::Count { stat: "foo".into(), val: 1.into() }, "", &["tag:1", "tag:2"])[..]
         )
     }
 
@@ -322,7 +245,7 @@ mod tests {
     fn test_format_for_send_everything() {
         assert_eq!(
             &b"namespace.foo:1|c|#tag:1,tag:2"[..],
-            &format_for_send(&CountMetric::Incr("foo"), "namespace", &["tag:1", "tag:2"])[..]
+            &format_for_send(&Metric::Count { stat: "foo".into(), val: 1.into() }, "namespace", &["tag:1", "tag:2"])[..]
         )
     }
 
@@ -330,116 +253,117 @@ mod tests {
     fn test_format_for_send_everything_omit_namespace() {
         assert_eq!(
             &b"_e{5,4}:title|text|#tag:1,tag:2"[..],
-            &format_for_send(&Event::new("title".into(), "text".into()), "namespace", &["tag:1", "tag:2"])[..]
+            &format_for_send(&Metric::Event { title: "title".into(), text: "text".into() }, "namespace", &["tag:1", "tag:2"])[..]
         )
     }
 
     #[test]
     fn test_count_incr_metric() {
-        let metric = CountMetric::Incr("incr".into());
+        let metric = Metric::Count { stat: "incr".into(), val: 1.into() };
 
         assert_eq!("incr:1|c", metric.metric_type_format())
     }
 
     #[test]
     fn test_count_decr_metric() {
-        let metric = CountMetric::Decr("decr".into());
+        let metric = Metric::Count { stat: "decr".into(), val: (-1).into() };
 
         assert_eq!("decr:-1|c", metric.metric_type_format())
     }
 
     #[test]
     fn test_time_metric() {
-        let ref start_time = Utc.ymd(2016, 4, 24).and_hms_milli(0, 0, 0, 0);
-        let ref end_time = Utc.ymd(2016, 4, 24).and_hms_milli(0, 0, 0, 900);
-        let metric = TimeMetric { stat: "time".into(), start_time, end_time };
+        let start_time = Utc.ymd(2016, 4, 24).and_hms_milli(0, 0, 0, 0);
+        let end_time = Utc.ymd(2016, 4, 24).and_hms_milli(0, 0, 0, 900);
+        let duration = end_time.signed_duration_since(start_time);
+        let metric = Metric::Timing { stat: "time".into(), val: duration.into() };
 
         assert_eq!("time:900|ms", metric.metric_type_format())
     }
 
     #[test]
     fn test_timing_metric() {
-        let metric = TimingMetric { stat: "timing".into(), ms: 720 };
+        let metric = Metric::Timing { stat: "timing".into(), val: 720.into() };
 
         assert_eq!("timing:720|ms", metric.metric_type_format())
     }
 
     #[test]
     fn test_gauge_metric() {
-        let metric = GaugeMetric { stat: "gauge".into(), val: 12345.into() };
+        let metric = Metric::Gauge { stat: "gauge".into(), val: 12345.into() };
 
         assert_eq!("gauge:12345|g", metric.metric_type_format())
     }
 
     #[test]
     fn test_histogram_metric() {
-        let metric = HistogramMetric { stat: "histogram".into(), val: 67890.into() };
+        let metric = Metric::Histogram { stat: "histogram".into(), val: 67890.into() };
 
         assert_eq!("histogram:67890|h", metric.metric_type_format())
     }
 
     #[test]
     fn test_distribution_metric() {
-        let metric = DistributionMetric { stat: "distribution".into(), val: 67890.into() };
+        let metric = Metric::Distribution { stat: "distribution".into(), val: 67890.into() };
 
         assert_eq!("distribution:67890|d", metric.metric_type_format())
     }
 
     #[test]
     fn test_set_metric() {
-        let metric = SetMetric { stat: "set".into(), val: 13579.into() };
+        let metric = Metric::Set { stat: "set".into(), val: 13579.into() };
 
         assert_eq!("set:13579|s", metric.metric_type_format())
     }
 
     #[test]
     fn test_service_check() {
-        let metric = ServiceCheck { stat: "redis.can_connect".into(), val: ServiceStatus::Warning, options: ServiceCheckOptions::default() };
+        let metric = Metric::ServiceCheck { stat: "redis.can_connect".into(), val: ServiceStatus::Warning, opt: ServiceCheckOptions::default() };
 
         assert_eq!("_sc|redis.can_connect|1", metric.metric_type_format())
     }
 
     #[test]
     fn test_service_check_with_timestamp() {
-        let options = ServiceCheckOptions {
+        let opt = ServiceCheckOptions {
             timestamp: Some(1234567890),
             ..Default::default()
         };
-        let metric = ServiceCheck { stat: "redis.can_connect".into(), val: ServiceStatus::Warning, options };
+        let metric = Metric::ServiceCheck { stat: "redis.can_connect".into(), val: ServiceStatus::Warning, opt };
 
         assert_eq!("_sc|redis.can_connect|1|d:1234567890", metric.metric_type_format())
     }
 
     #[test]
     fn test_service_check_with_hostname() {
-        let options = ServiceCheckOptions {
+        let opt = ServiceCheckOptions {
             hostname: Some("my_server.localhost"),
             ..Default::default()
         };
-        let metric = ServiceCheck { stat: "redis.can_connect".into(), val: ServiceStatus::Warning, options };
+        let metric = Metric::ServiceCheck { stat: "redis.can_connect".into(), val: ServiceStatus::Warning, opt };
 
         assert_eq!("_sc|redis.can_connect|1|h:my_server.localhost", metric.metric_type_format())
     }
 
     #[test]
     fn test_service_check_with_message() {
-        let options = ServiceCheckOptions {
+        let opt = ServiceCheckOptions {
             message: Some("Service is possibly down"),
             ..Default::default()
         };
-        let metric = ServiceCheck { stat: "redis.can_connect".into(), val: ServiceStatus::Warning, options };
+        let metric = Metric::ServiceCheck { stat: "redis.can_connect".into(), val: ServiceStatus::Warning, opt };
 
         assert_eq!("_sc|redis.can_connect|1|m:Service is possibly down", metric.metric_type_format())
     }
 
     #[test]
     fn test_service_check_with_all() {
-        let options = ServiceCheckOptions {
+        let opt = ServiceCheckOptions {
             timestamp: Some(1234567890),
             hostname: Some("my_server.localhost"),
             message: Some("Service is possibly down")
         };
-        let metric = ServiceCheck { stat: "redis.can_connect".into(), val: ServiceStatus::Warning, options };
+        let metric = Metric::ServiceCheck { stat: "redis.can_connect".into(), val: ServiceStatus::Warning, opt };
 
         assert_eq!(
             "_sc|redis.can_connect|1|d:1234567890|h:my_server.localhost|m:Service is possibly down",
@@ -449,7 +373,7 @@ mod tests {
 
     #[test]
     fn test_event() {
-        let metric = Event::new("Event Title".into(), "Event Body - Something Happened".into());
+        let metric = Metric::Event { title: "Event Title".into(), text: "Event Body - Something Happened".into() };
 
         assert_eq!(
             "_e{11,31}:Event Title|Event Body - Something Happened",

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -117,6 +117,24 @@ pub enum Measurement {
     Float(f64),
 }
 
+macro_rules! measurement_from {
+    ($t:ty, Int) => (
+        impl From<$t> for Measurement {
+            fn from(value: $t) -> Measurement {
+                Measurement::Int(value as i64)
+            }
+        }
+    );
+
+    ($t:ty, Float) => (
+        impl From<$t> for Measurement {
+            fn from(value: $t) -> Measurement {
+                Measurement::Float(value as f64)
+            }
+        }
+    )
+}
+
 macro_rules! measurement_metric {
     ($t:ident, $suffix:expr) => (
 
@@ -139,24 +157,6 @@ macro_rules! measurement_metric {
                 buf.push_str(&val);
                 buf.push_str($suffix);
                 buf
-            }
-        }
-    )
-}
-
-macro_rules! measurement_from {
-    ($t:ty, Int) => (
-        impl From<$t> for Measurement {
-            fn from(value: $t) -> Measurement {
-                Measurement::Int(value as i64)
-            }
-        }
-    );
-
-    ($t:ty, Float) => (
-        impl From<$t> for Measurement {
-            fn from(value: $t) -> Measurement {
-                Measurement::Float(value as f64)
             }
         }
     )


### PR DESCRIPTION
Various updates:
- support for passing ints and floats in client methods
- use `enum` for metrics
- `rated` variants to match the [Go client](https://github.com/DataDog/datadog-go/blob/19be5e3f81ca0166e94b4f79afb835bc55756b9f/statsd/statsd.go#L325-L327)
- extra options for events (might resolve https://github.com/mcasper/dogstatsd-rs/issues/20)
- removed most uses of `Cow`

Regarding rated versions, I would be tempted to remove the non-rated but this means taking `&mut self` references everywhere; perhaps this isn't an issue. Having rated also means a dependency on `rand`.
