### PR TITLE
Add arbitrary count method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -576,8 +576,13 @@ mod bench {
         let options = Options::default();
         let client = Client::new(options).unwrap();
         let tags = vec!["name1:value1"];
+        let all_options = ServiceCheckOptions {
+            hostname: Some("my-host.localhost"),
+            timestamp: Some(1510326433),
+            message: Some("Message about the check or service")
+        };
         b.iter(|| {
-            client.service_check("bench.service_check", ServiceStatus::Critical, &tags).unwrap();
+            client.service_check("bench.service_check", ServiceStatus::Critical, &tags, Some(all_options)).unwrap();
         })
     }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -51,6 +51,7 @@ pub trait Metric {
 pub enum CountMetric<'a> {
     Incr(&'a str),
     Decr(&'a str),
+    Arbitrary(&'a str, i64),
 }
 
 impl<'a> Metric for CountMetric<'a> {
@@ -70,6 +71,14 @@ impl<'a> Metric for CountMetric<'a> {
                 buf.push_str(":-1|c");
                 buf
             },
+            CountMetric::Arbitrary(stat, amount) => {
+                let mut buf = String::with_capacity(3 + stat.len() + 23);
+                buf.push_str(stat);
+                buf.push_str(":");
+                buf.push_str(&amount.to_string());
+                buf.push_str("|c");
+                buf
+            }
         }
     }
 }
@@ -421,6 +430,16 @@ mod tests {
         let metric = CountMetric::Decr("decr".into());
 
         assert_eq!("decr:-1|c", metric.metric_type_format())
+    }
+
+    #[test]
+    fn test_count_metric() {
+        let metric = CountMetric::Arbitrary("arb".into(), 54321);
+        assert_eq!("arb:54321|c", metric.metric_type_format());
+        let metric = CountMetric::Arbitrary("arb".into(), -12345);
+        assert_eq!("arb:-12345|c", metric.metric_type_format());
+        let metric = CountMetric::Arbitrary("arb".into(), 0);
+        assert_eq!("arb:0|c", metric.metric_type_format());
     }
 
     #[test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -65,7 +65,7 @@ impl<'a> Metric for CountMetric<'a> {
                 buf
             },
             CountMetric::Decr(stat) => {
-                let mut buf = String::with_capacity(3 + stat.len() + 4);
+                let mut buf = String::with_capacity(3 + stat.len() + 5);
                 buf.push_str(stat);
                 buf.push_str(":-1|c");
                 buf

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -540,13 +540,22 @@ mod bench {
     use self::test::Bencher;
     use super::*;
 
-    #[bench]
-    fn bench_format_for_send(b: &mut Bencher) {
-        b.iter(|| {
-            format_for_send("metric", "foo", &["bar", "baz"]);
-        })
+    struct NullMetric;
+
+    impl Metric for NullMetric {
+        fn metric_type_format(&self) -> String {
+            String::new()
+        }
     }
 
+    #[bench]
+    fn bench_format_for_send(b: &mut Bencher) {
+        let metric = NullMetric;
+
+        b.iter(|| {
+            format_for_send(&metric, "foo", &["bar", "baz"]);
+        })
+    }
 
     #[bench]
     fn bench_set_metric(b: &mut Bencher) {


### PR DESCRIPTION
Sometimes in hot-path code it is more economical to track a counter internally and only update the StatsD instance periodically. This is as opposed to using `incr` and `decr` repeatedly. So this PR  adds a `count` method that takes an arbitrary integer value to update a counter statistic by.

Also fixed a couple random bugs:
- Benchmarks were failing to compile due to library changes (the benchmarks aren't normally run so it's easy to miss breaking changes)
-  The decrement metric wasn't pre-allocating enough string space so it would end up allocating every time anyway.