### PR TITLE
Allow deprecated use of Error::description

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -20,9 +20,9 @@ impl fmt::Display for DogstatsdError {
 }
 
 impl Error for DogstatsdError {
-    fn description(&self) -> &str {
-        match *self {
-            IoError(ref error) => error.description(),
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            IoError(error) => Some(error),
         }
     }
 }


### PR DESCRIPTION
dogstatsd currently fails to compile:

```
error: use of deprecated associated function `std::error::Error::description`: use the Display impl or to_string()
  --> src/error.rs:25:41
   |
25 |             IoError(ref error) => error.description(),
   |                                         ^^^^^^^^^^^
   |
note: the lint level is defined here
  --> src/lib.rs:72:9
   |
72 | #![deny(warnings, missing_debug_implementations, missing_copy_implementations, missing_docs)]
   |         ^^^^^^^^
   = note: `#[deny(deprecated)]` implied by `#[deny(warnings)]`
```

This pull request fixes this with a `#[allow(deprecated)]` at the call site. This is a very conservative fix, and ordinarily I would prefer to remove the use of deprecated APIs, but since this call is in an implementation of `Error::description` on another type, it seems sensible to allow this.