### PR TITLE
Adding default tags to Options and Client and sending the default tags with each metric and event

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ let default_options = Options::default();
 let default_client = Client::new(default_options).unwrap();
 
 // Binds to 127.0.0.1:9000 for transmitting and sends to 10.1.2.3:8125, with a
-// namespace of "analytics".
-let custom_options = Options::new("127.0.0.1:9000", "10.1.2.3:8125", "analytics");
+// namespace of "analytics", and a default tag of "region:west".
+let custom_options = Options::new("127.0.0.1:9000", "10.1.2.3:8125", "analytics", "region:west");
 let custom_client = Client::new(custom_options).unwrap();
 ```
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 
-pub fn format_for_send<M, I, S>(in_metric: &M, in_namespace: &str, tags: I) -> Vec<u8>
+pub fn format_for_send<M, I, S>(in_metric: &M, in_namespace: &str, tags: I, default_tags: &Vec<u8>) -> Vec<u8>
     where M: Metric,
           I: IntoIterator<Item=S>,
           S: AsRef<str>,
@@ -35,6 +35,11 @@ pub fn format_for_send<M, I, S>(in_metric: &M, in_namespace: &str, tags: I) -> V
         if next_tag.is_some() {
             buf.extend_from_slice(b",");
         }
+    }
+
+    if !default_tags.is_empty() {
+        buf.extend_from_slice(b",");
+        buf.extend_from_slice(&default_tags);
     }
 
     buf
@@ -390,7 +395,7 @@ mod tests {
     fn test_format_for_send_no_tags() {
         assert_eq!(
             &b"namespace.foo:1|c"[..],
-            &format_for_send(&CountMetric::Incr("foo"), "namespace", &[] as &[String])[..]
+            &format_for_send(&CountMetric::Incr("foo"), "namespace", &[] as &[String], &String::default().into_bytes())[..]
         )
     }
 
@@ -398,15 +403,23 @@ mod tests {
     fn test_format_for_send_no_namespace() {
         assert_eq!(
             &b"foo:1|c|#tag:1,tag:2"[..],
-            &format_for_send(&CountMetric::Incr("foo"), "", &["tag:1", "tag:2"])[..]
+            &format_for_send(&CountMetric::Incr("foo"), "", &["tag:1", "tag:2"], &String::default().into_bytes())[..]
+        )
+    }
+
+    #[test]
+    fn test_format_for_no_default_tags() {
+        assert_eq!(
+            &b"namespace.foo:1|c|#tag:1,tag:2,defaultag:3,seconddefault:4"[..],
+            &format_for_send(&CountMetric::Incr("foo"), "namespace", &["tag:1", "tag:2"], &String::from("defaultag:3,seconddefault:4").into_bytes())[..]
         )
     }
 
     #[test]
     fn test_format_for_send_everything() {
         assert_eq!(
-            &b"namespace.foo:1|c|#tag:1,tag:2"[..],
-            &format_for_send(&CountMetric::Incr("foo"), "namespace", &["tag:1", "tag:2"])[..]
+            &b"namespace.foo:1|c|#tag:1,tag:2,defaultag:3,seconddefault:4"[..],
+            &format_for_send(&CountMetric::Incr("foo"), "namespace", &["tag:1", "tag:2"], &String::from("defaultag:3,seconddefault:4").into_bytes())[..]
         )
     }
 
@@ -414,7 +427,7 @@ mod tests {
     fn test_format_for_send_everything_omit_namespace() {
         assert_eq!(
             &b"_e{5,4}:title|text|#tag:1,tag:2"[..],
-            &format_for_send(&Event::new("title".into(), "text".into()), "namespace", &["tag:1", "tag:2"])[..]
+            &format_for_send(&Event::new("title".into(), "text".into()), "namespace", &["tag:1", "tag:2"], &String::default().into_bytes())[..]
         )
     }
 


### PR DESCRIPTION
We had a use case where we wanted to instantiate default tags that are sent along with every metric and event.

This adds the capability while adding some likely minor optimizations by converting the passed in default tags to a byte Vec once during client initialization.

The current downside is that it can require code changes for anyone bumping versions using this library.