### PR TITLE
Optimizations and styling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,7 +199,7 @@ impl OptionsBuilder {
     ///
     ///   let options_builder = OptionsBuilder::new().from_addr(String::from("127.0.0.1:9000"));
     /// ```
-    pub fn from_addr<'a>(&'a mut self, from_addr: String) -> &'a mut OptionsBuilder {
+    pub fn from_addr(&mut self, from_addr: String) -> &mut OptionsBuilder {
         self.from_addr = Some(from_addr);
         self
     }
@@ -213,7 +213,7 @@ impl OptionsBuilder {
     ///
     ///   let options_builder = OptionsBuilder::new().to_addr(String::from("127.0.0.1:9001"));
     /// ```
-    pub fn to_addr<'a>(&'a mut self, to_addr: String) -> &'a mut OptionsBuilder {
+    pub fn to_addr(&mut self, to_addr: String) -> &mut OptionsBuilder {
         self.to_addr = Some(to_addr);
         self
     }
@@ -227,7 +227,7 @@ impl OptionsBuilder {
     ///
     ///   let options_builder = OptionsBuilder::new().namespace(String::from("mynamespace"));
     /// ```
-    pub fn namespace<'a>(&'a mut self, namespace: String) -> &'a mut OptionsBuilder {
+    pub fn namespace(&mut self, namespace: String) -> &mut OptionsBuilder {
         self.namespace = Some(namespace);
         self
     }
@@ -241,7 +241,7 @@ impl OptionsBuilder {
     ///
     ///   let options_builder = OptionsBuilder::new().default_tag(String::from("tag1:tav1val")).default_tag(String::from("tag2:tag2val"));
     /// ```
-    pub fn default_tag<'a>(&'a mut self, default_tag: String) -> &'a mut OptionsBuilder {
+    pub fn default_tag(&mut self, default_tag: String) -> &mut OptionsBuilder {
         self.default_tags.push(default_tag);
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,7 @@ impl Options {
 }
 
 /// Struct that allows build an `Options` for available for the Dogstatsd client.
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct OptionsBuilder {
     /// The address of the udp socket we'll bind to for sending.
     from_addr: Option<String>,
@@ -182,12 +182,7 @@ impl OptionsBuilder {
     ///   let options_builder = OptionsBuilder::new();
     /// ```
     pub fn new() -> Self {
-        Self {
-            from_addr: Option::None,
-            to_addr: Option::None,
-            namespace: Option::None,
-            default_tags: Vec::new()
-        }
+        Self::default()
     }
 
     /// Will allow the builder to generate an `Options` struct with the provided value.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,9 +268,9 @@ impl OptionsBuilder {
     /// ```
     pub fn build(&self) -> Options {
         Options::new(
-            &self.from_addr.as_ref().unwrap_or(&String::from(DEFAULT_FROM_ADDR)),
-            &self.to_addr.as_ref().unwrap_or(&String::from(DEFAULT_TO_ADDR)),
-            &self.namespace.as_ref().unwrap_or(&String::default()),
+            self.from_addr.as_ref().unwrap_or(&String::from(DEFAULT_FROM_ADDR)),
+            self.to_addr.as_ref().unwrap_or(&String::from(DEFAULT_TO_ADDR)),
+            self.namespace.as_ref().unwrap_or(&String::default()),
             self.default_tags.to_vec()
         )
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -277,7 +277,7 @@ impl ServiceStatus {
 }
 
 /// Struct for adding optional pieces to a service check
-#[derive(Clone, Copy, Debug)]
+#[derive(Default, Clone, Copy, Debug)]
 pub struct ServiceCheckOptions {
     /// An optional timestamp to include with the check
     pub timestamp: Option<i32>,
@@ -285,16 +285,6 @@ pub struct ServiceCheckOptions {
     pub hostname: Option<&'static str>,
     /// An optional message to include with the check
     pub message: Option<&'static str>,
-}
-
-impl Default for ServiceCheckOptions {
-    fn default() -> Self {
-        ServiceCheckOptions {
-            timestamp: None,
-            hostname: None,
-            message: None,
-        }
-    }
 }
 
 impl ServiceCheckOptions {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -43,7 +43,7 @@ pub fn format_for_send<M, I, S>(in_metric: &M, in_namespace: &str, tags: I, defa
             buf.extend_from_slice(b",")
         }
 
-        buf.extend_from_slice(&default_tags);
+        buf.extend_from_slice(default_tags);
     }
 
     buf

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -83,7 +83,7 @@ impl<'a> Metric for CountMetric<'a> {
             CountMetric::Arbitrary(stat, amount) => {
                 let mut buf = String::with_capacity(3 + stat.len() + 23);
                 buf.push_str(stat);
-                buf.push_str(":");
+                buf.push(':');
                 buf.push_str(&amount.to_string());
                 buf.push_str("|c");
                 buf
@@ -104,7 +104,7 @@ impl<'a> Metric for TimeMetric<'a> {
         let dur = self.end_time.signed_duration_since(*self.start_time);
         let mut buf = String::with_capacity(3 + self.stat.len() + 11);
         buf.push_str(self.stat);
-        buf.push_str(":");
+        buf.push(':');
         buf.push_str(&dur.num_milliseconds().to_string());
         buf.push_str("|ms");
         buf
@@ -132,7 +132,7 @@ impl<'a> Metric for TimingMetric<'a> {
         let ms = self.ms.to_string();
         let mut buf = String::with_capacity(3 + self.stat.len() + ms.len());
         buf.push_str(self.stat);
-        buf.push_str(":");
+        buf.push(':');
         buf.push_str(&ms);
         buf.push_str("|ms");
         buf
@@ -158,7 +158,7 @@ impl<'a> Metric for GaugeMetric<'a> {
     fn metric_type_format(&self) -> String {
         let mut buf = String::with_capacity(3 + self.stat.len() + self.val.len());
         buf.push_str(self.stat);
-        buf.push_str(":");
+        buf.push(':');
         buf.push_str(self.val);
         buf.push_str("|g");
         buf
@@ -184,7 +184,7 @@ impl<'a> Metric for HistogramMetric<'a> {
     fn metric_type_format(&self) -> String {
         let mut buf = String::with_capacity(3 + self.stat.len() + self.val.len());
         buf.push_str(self.stat);
-        buf.push_str(":");
+        buf.push(':');
         buf.push_str(self.val);
         buf.push_str("|h");
         buf
@@ -210,7 +210,7 @@ impl<'a>Metric for DistributionMetric<'a> {
     fn metric_type_format(&self) -> String {
         let mut buf = String::with_capacity(3 + self.stat.len() + self.val.len());
         buf.push_str(self.stat);
-        buf.push_str(":");
+        buf.push(':');
         buf.push_str(self.val);
         buf.push_str("|d");
         buf
@@ -236,7 +236,7 @@ impl<'a> Metric for SetMetric<'a> {
     fn metric_type_format(&self) -> String {
         let mut buf = String::with_capacity(3 + self.stat.len() + self.val.len());
         buf.push_str(self.stat);
-        buf.push_str(":");
+        buf.push(':');
         buf.push_str(self.val);
         buf.push_str("|s");
         buf
@@ -323,7 +323,7 @@ impl<'a> Metric for ServiceCheck<'a> {
         let mut buf = String::with_capacity(6 + self.stat.len() + self.options.len());
         buf.push_str("_sc|");
         buf.push_str(self.stat);
-        buf.push_str("|");
+        buf.push('|');
         buf.push_str(&format!("{}", self.val.to_int()));
 
         if self.options.timestamp.is_some() {
@@ -371,11 +371,11 @@ impl<'a> Metric for Event<'a> {
         let mut buf = String::with_capacity(self.title.len() + self.text.len() + title_len.len() + text_len.len() + 6);
         buf.push_str("_e{");
         buf.push_str(&title_len);
-        buf.push_str(",");
+        buf.push(',');
         buf.push_str(&text_len);
         buf.push_str("}:");
         buf.push_str(self.title);
-        buf.push_str("|");
+        buf.push('|');
         buf.push_str(self.text);
         buf
     }


### PR DESCRIPTION
This branch is to fix some things that could be improved in the codebase. One another change i left is to change `ServiceStatus::to_int` function. In that function isn't necessary to pass the reference of `self` but it's enough to pass `self` as a value (being that `ServiceStatus` derives `Copy`)