### PR TITLE
Added support for incrementing by a specified value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,7 +337,27 @@ impl Client {
         S: Into<Cow<'a, str>>,
         T: AsRef<str>,
     {
-        self.send(&CountMetric::Incr(stat.into().as_ref()), tags)
+        self.send(&CountMetric::Incr(stat.into().as_ref(), 1), tags)
+    }
+
+    /// Increment a StatsD counter by the provided amount
+    ///
+    /// # Examples
+    ///
+    /// ```
+    ///   use dogstatsd::{Client, Options};
+    ///
+    ///   let client = Client::new(Options::default()).unwrap();
+    ///   client.incr_by_value("counter", 123, &["tag:counter"])
+    ///       .unwrap_or_else(|e| println!("Encountered error: {}", e));
+    /// ```
+    pub fn incr_by_value<'a, I, S, T>(&self, stat: S, value: i64, tags: I) -> DogstatsdResult
+    where
+        I: IntoIterator<Item = T>,
+        S: Into<Cow<'a, str>>,
+        T: AsRef<str>,
+    {
+        self.send(&CountMetric::Incr(stat.into().as_ref(), value), tags)
     }
 
     /// Decrement a StatsD counter
@@ -357,7 +377,27 @@ impl Client {
         S: Into<Cow<'a, str>>,
         T: AsRef<str>,
     {
-        self.send(&CountMetric::Decr(stat.into().as_ref()), tags)
+        self.send(&CountMetric::Decr(stat.into().as_ref(), 1), tags)
+    }
+
+    /// Decrement a StatsD counter by the provided amount
+    ///
+    /// # Examples
+    ///
+    /// ```
+    ///   use dogstatsd::{Client, Options};
+    ///
+    ///   let client = Client::new(Options::default()).unwrap();
+    ///   client.decr("counter", 23, &["tag:counter"])
+    ///       .unwrap_or_else(|e| println!("Encountered error: {}", e));
+    /// ```
+    pub fn decr_by_value<'a, I, S, T>(&self, stat: S, value: i64, tags: I) -> DogstatsdResult
+    where
+        I: IntoIterator<Item = T>,
+        S: Into<Cow<'a, str>>,
+        T: AsRef<str>,
+    {
+        self.send(&CountMetric::Decr(stat.into().as_ref(), value), tags)
     }
 
     /// Make an arbitrary change to a StatsD counter

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -388,7 +388,7 @@ impl Client {
     ///   use dogstatsd::{Client, Options};
     ///
     ///   let client = Client::new(Options::default()).unwrap();
-    ///   client.decr("counter", 23, &["tag:counter"])
+    ///   client.decr_by_value("counter", 23, &["tag:counter"])
     ///       .unwrap_or_else(|e| println!("Encountered error: {}", e));
     /// ```
     pub fn decr_by_value<'a, I, S, T>(&self, stat: S, value: i64, tags: I) -> DogstatsdResult

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -75,13 +75,13 @@ impl<'a> Metric for CountMetric<'a> {
     fn metric_type_format(&self) -> String {
         match *self {
             CountMetric::Incr(stat, amount) => {
-                let mut buf = String::with_capacity(3 + stat.len() + amount.to_string().len() + 4);
+                let mut buf = String::with_capacity(3 + stat.len() + amount.to_string().len() + 3);
                 buf.push_str(stat);
                 buf.push_str(&format!(":{}|c", amount));
                 buf
             }
             CountMetric::Decr(stat, amount) => {
-                let mut buf = String::with_capacity(3 + stat.len() + amount.to_string().len() + 5);
+                let mut buf = String::with_capacity(3 + stat.len() + amount.to_string().len() + 4);
                 buf.push_str(stat);
                 buf.push_str(&format!(":{}|c", amount * -1));
                 buf

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -75,13 +75,13 @@ impl<'a> Metric for CountMetric<'a> {
     fn metric_type_format(&self) -> String {
         match *self {
             CountMetric::Incr(stat, amount) => {
-                let mut buf = String::with_capacity(3 + stat.len() + 4);
+                let mut buf = String::with_capacity(3 + stat.len() + amount.to_string().len() + 4);
                 buf.push_str(stat);
                 buf.push_str(&format!(":{}|c", amount));
                 buf
             }
             CountMetric::Decr(stat, amount) => {
-                let mut buf = String::with_capacity(3 + stat.len() + 5);
+                let mut buf = String::with_capacity(3 + stat.len() + amount.to_string().len() + 5);
                 buf.push_str(stat);
                 buf.push_str(&format!(":{}|c", amount * -1));
                 buf


### PR DESCRIPTION
It is fairly common to increment a counter by a known amount, instead of just by `1`. This adds API support for that use case

# API added
- `incr_by_value(stat, value, tags)`
- `decr_by_value(stat, value, tags)`