### PR TITLE
Allow copy clone of EventOptions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -992,7 +992,7 @@ impl Client {
 /// };
 /// ```
 ///
-#[derive(Debug, PartialEq)]
+#[derive(Default, Clone, Copy, Debug)]
 pub struct EventOptions<'a> {
     /// Optional Unix timestamp representing the event time. The default is the current Unix epoch timestamp.
     pub timestamp: Option<u64>,
@@ -1455,8 +1455,8 @@ mod bench {
         let event_options = EventOptions::new()
             .with_timestamp(1638480000)
             .with_hostname("localhost")
-            .with_priority("normal")
-            .with_alert_type("error");
+            .with_priority(EventPriority::Normal)
+            .with_alert_type(EventAlertType::Error);
 
         b.iter(|| {
             client

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -333,10 +333,11 @@ impl<'a> ServiceCheck<'a> {
 }
 
 /// Represents priority levels for an event.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
 pub enum EventPriority {
     ///low
     Low,
+    #[default]
     ///normal
     Normal,
 }
@@ -352,8 +353,9 @@ impl EventPriority {
 }
 
 /// Represents alert types for an event.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
 pub enum EventAlertType {
+    #[default]
     /// info
     Info,
     /// warning


### PR DESCRIPTION
Doing some high-level library wrapper integration, I noticed that having the copy/clone traits implemented will improve the developer experience :) 