### PR TITLE
Update tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ retry = "2.0.0"
 
 [dev-dependencies]
 tokio = { version = "1.32", features = ["full"] }
+serial_test = "3.2.0"
 
 [features]
 unstable = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1173,6 +1173,7 @@ mod batch_processor {
 #[cfg(test)]
 mod tests {
     use metrics::GaugeMetric;
+    use serial_test::serial;
 
     use super::*;
 
@@ -1223,6 +1224,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_new() {
         let client = Client::new(Options::default()).unwrap();
         let expected_client = Client {
@@ -1237,6 +1239,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_new_default_tags() {
         let options = Options::new(
             DEFAULT_FROM_ADDR,
@@ -1259,6 +1262,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_system_tags() {
         let options = Options::new(
             DEFAULT_FROM_ADDR,
@@ -1299,13 +1303,17 @@ mod tests {
     }
 
     fn with_default_system_tags<T, F: FnOnce() -> T>(f: F) -> T {
-        std::env::set_var("DD_ENV", "production");
-        std::env::set_var("DD_SERVICE", "service");
-        std::env::set_var("DD_VERSION", "0.0.1");
+        unsafe {
+            std::env::set_var("DD_ENV", "production");
+            std::env::set_var("DD_SERVICE", "service");
+            std::env::set_var("DD_VERSION", "0.0.1");
+        }
         let t = f();
-        std::env::remove_var("DD_ENV");
-        std::env::remove_var("DD_SERVICE");
-        std::env::remove_var("DD_VERSION");
+        unsafe {
+            std::env::remove_var("DD_ENV");
+            std::env::remove_var("DD_SERVICE");
+            std::env::remove_var("DD_VERSION");
+        }
         t
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,9 +1,9 @@
 mod support;
 
-use std::{thread, time::Duration};
+use std::time::Duration;
 
 use dogstatsd::{BatchingOptions, Client, OptionsBuilder};
-use tokio::{sync::mpsc::Receiver, time::timeout};
+use tokio::{sync::mpsc::Receiver, time::{sleep, timeout}};
 
 use crate::support::TestServer;
 
@@ -65,7 +65,7 @@ async fn batching_test() {
     // The batch processor requires a metric to be sent _after_ the timeout has been reached
     // to flush the buffer. Ideally there would be a separate timer running to automatically flush it,
     // but for now we'll make do with a sleep.
-    thread::sleep(Duration::from_secs(2));
+    sleep(Duration::from_secs(2)).await;
 
     client
         .timing("my_timing", 311, &["tag1:value1"])


### PR DESCRIPTION
- Use `#[serial]` on tests that read or write env vars
- Mutate env vars from unsafe code