### PR TITLE
Fix non-Unix build break from clippy retry refactor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1099,7 +1099,7 @@ mod batch_processor {
             Exponential::from_millis(batching_options.initial_retry_delay)
                 .map(jitter)
                 .take(batching_options.max_retry_attempts),
-            || {
+            || -> Result<(), std::io::Error> {
                 match socket {
                     SocketType::Udp(socket) => {
                         socket.send_to(data.as_slice(), to_addr)?;


### PR DESCRIPTION
The clippy cleanup switched UDP `send_to` handling to `?` inside the retry closure.

On Unix, the UDS branch still returns `Err(error)`, which pins the closure error type. On non-Unix targets that branch is cfg'd out, leaving the retry error type unconstrained and causing E0282 during compilation.

This change fixes compilation on Windows by explicitly typing the retry closure as `Result<(), std::io::Error>` so type inference is stable across platforms.