### PR TITLE
[codex] Flush DogStatsD batches before exceeding size limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Flush a batch before adding a metric that would exceed `BatchingOptions::max_buffer_size`.
+
 ## [0.12.3] - 2026-02-16
 
 ### Fixed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1148,9 +1148,21 @@ mod batch_processor {
         loop {
             match rx.recv() {
                 Ok(Message::Data(data)) => {
-                    for ch in data {
-                        buffer.push(ch);
+                    let next_buffer_size = buffer.len() + data.len() + 1;
+
+                    if !buffer.is_empty() && next_buffer_size > batching_options.max_buffer_size {
+                        send_to_socket_with_retries(
+                            &batching_options,
+                            &socket,
+                            &buffer,
+                            &to_addr,
+                            &socket_path,
+                        );
+                        buffer.clear();
+                        last_updated = SystemTime::now();
                     }
+
+                    buffer.extend(data);
                     buffer.push(b'\n');
 
                     let current_time = SystemTime::now();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -91,3 +91,47 @@ async fn batching_test() {
         );
     }
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn batching_flushes_before_the_next_metric_exceeds_the_limit() {
+    let server = TestServer::new("127.0.0.1:8128".into()).await;
+    let max_buffer_size = 32;
+    let opts = OptionsBuilder::new()
+        .to_addr("127.0.0.1:8128".into())
+        .batching_options(BatchingOptions {
+            max_time: Duration::from_secs(30),
+            max_buffer_size,
+            max_retry_attempts: 0,
+            initial_retry_delay: 25,
+        })
+        .build();
+    let client = Client::new(opts).unwrap();
+
+    let mut promise = server.lock().unwrap().next_message_received();
+    client
+        .gauge("first", "1", ["tag:value"])
+        .expect("unable to send first stat");
+    client
+        .gauge("second", "2", ["tag:value"])
+        .expect("unable to send second stat");
+    drop(client);
+
+    timeout(Duration::from_secs(1), promise.recv())
+        .await
+        .expect("didn't receive first packet within a second")
+        .expect("notification channel closed before the first packet");
+    timeout(Duration::from_secs(1), promise.recv())
+        .await
+        .expect("didn't receive second packet within a second")
+        .expect("notification channel closed before the second packet");
+
+    let shared = server.lock().unwrap();
+    assert_eq!(
+        shared.messages(),
+        ["first:1|g|#tag:value\n", "second:2|g|#tag:value\n"]
+    );
+    assert!(shared
+        .messages()
+        .iter()
+        .all(|packet| packet.len() <= max_buffer_size));
+}

--- a/tests/support.rs
+++ b/tests/support.rs
@@ -66,6 +66,10 @@ impl TestServer {
         self.messages.last()
     }
 
+    pub fn messages(&self) -> &[String] {
+        &self.messages
+    }
+
     pub fn next_message_received(&mut self) -> Receiver<()> {
         let (tx, rx) = mpsc::channel::<()>(1);
         self.on_next_message = Some(tx);


### PR DESCRIPTION
## Summary

- flush the current batch before appending a metric that would make the batch exceed `BatchingOptions::max_buffer_size`
- measure the formatted metric, including tags and its trailing newline
- preserve the existing behavior for an individual metric that exceeds the configured size by sending it on its own
- add regression coverage for the pre-append flush behavior

## Root cause

The batch processor previously appended a metric and its newline before checking the buffer length. As a result, a multi-metric batch could exceed `max_buffer_size` by the size of its final metric. Receivers with a datagram limit could then truncate or reject that packet.

## Impact

Accumulating metrics no longer causes a batch to cross the configured byte limit. An individual oversized metric is still emitted on its own, and non-batched clients are unchanged.

## Validation

- `cargo test`
- `cargo clippy --lib -- -D warnings`
